### PR TITLE
Rearrange include list in module definition so that "defintions.jl" is above "spatial_structure.jl"

### DIFF
--- a/src/GeneDrive.jl
+++ b/src/GeneDrive.jl
@@ -21,18 +21,22 @@ import DataFrames
 # Files
 #####################
 # TODO: Random.seed!(123)
+include("organisms.jl")
+include("life_stages.jl")
+include("genetics.jl")
 include("definitions.jl") # Hard coded values of type const, keep at top definition
+
+
+
 include("temperature.jl")
 include("temperature_responses.jl")
 
-include("life_stages.jl")
-include("genetics.jl")
-include("organisms.jl")
+
 
 include("spatial_structure.jl")
 include("exogenous_change.jl")
-
 include("accessors.jl")
+
 
 
 include("initialize.jl")

--- a/src/GeneDrive.jl
+++ b/src/GeneDrive.jl
@@ -24,15 +24,13 @@ import DataFrames
 
 
 include("genetics.jl")
-include("organisms.jl")
-
-
 
 
 include("temperature.jl")
 include("temperature_responses.jl")
 
 include("life_stages.jl") 
+include("organisms.jl")
 include("definitions.jl")  
 
 include("spatial_structure.jl")

--- a/src/GeneDrive.jl
+++ b/src/GeneDrive.jl
@@ -25,7 +25,7 @@ import DataFrames
 
 include("genetics.jl")
 include("organisms.jl")
-include("definitions.jl") # Hard coded values of type const, keep at top definition
+
 
 
 
@@ -33,7 +33,7 @@ include("temperature.jl")
 include("temperature_responses.jl")
 
 include("life_stages.jl") 
-
+include("definitions.jl")  
 
 include("spatial_structure.jl")
 include("exogenous_change.jl")

--- a/src/GeneDrive.jl
+++ b/src/GeneDrive.jl
@@ -22,7 +22,7 @@ import DataFrames
 #####################
 # TODO: Random.seed!(123)
 
-include("life_stages.jl")
+
 include("genetics.jl")
 include("organisms.jl")
 include("definitions.jl") # Hard coded values of type const, keep at top definition
@@ -32,6 +32,7 @@ include("definitions.jl") # Hard coded values of type const, keep at top definit
 include("temperature.jl")
 include("temperature_responses.jl")
 
+include("life_stages.jl") 
 
 
 include("spatial_structure.jl")

--- a/src/GeneDrive.jl
+++ b/src/GeneDrive.jl
@@ -21,9 +21,10 @@ import DataFrames
 # Files
 #####################
 # TODO: Random.seed!(123)
-include("organisms.jl")
+
 include("life_stages.jl")
 include("genetics.jl")
+include("organisms.jl")
 include("definitions.jl") # Hard coded values of type const, keep at top definition
 
 

--- a/src/GeneDrive.jl
+++ b/src/GeneDrive.jl
@@ -21,6 +21,7 @@ import DataFrames
 # Files
 #####################
 # TODO: Random.seed!(123)
+include("definitions.jl") # Hard coded values of type const, keep at top definition
 include("temperature.jl")
 include("temperature_responses.jl")
 
@@ -32,7 +33,7 @@ include("spatial_structure.jl")
 include("exogenous_change.jl")
 
 include("accessors.jl")
-include("definitions.jl")
+
 
 include("initialize.jl")
 include("population_dynamics.jl")

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -2,26 +2,49 @@
 #                                   Mappings                                   #
 ################################################################################
 
-const life_stage_key_map =
-    Dict("Egg" => Egg, "Larva" => Larva, "Pupa" => Pupa, "Male" => Male, "Female" => Female)
 
-const genetics_key_map = Dict(
-    "WW" => WW,
-    "ww" => ww,
-    # end Wolbachia
-    "HH" => HH,
-    "Hh" => Hh,
-    "HR" => HR,
-    "hh" => hh,
-    "hR" => hR,
-    "RR" => RR,
-    # end single-locus homing gene drive (HGD/MCR)
-    "WR" => WR,
-    # end RIDL (total = WW, WR, RR)
-    "AA" => AA,
-    "Aa" => Aa,
-    "aa" => aa,
-    # end Mendelian
-)
+
+const life_stage_key_map = 
+
+        Dict(
+            "Egg" => Egg, 
+            "Larva" => Larva, 
+            "Pupa" => Pupa, 
+            "Male" => Male, 
+            "Female" => Female)
+
+const genetics_key_map = 
+    Dict(
+        "WW" => WW,
+        "ww" => ww,
+        # end Wolbachia
+        "HH" => HH,
+        "Hh" => Hh,
+        "HR" => HR,
+        "hh" => hh,
+        "hR" => hR,
+        "RR" => RR,
+        # end single-locus homing gene drive (HGD/MCR)
+        "WR" => WR,
+        # end RIDL (total = WW, WR, RR)
+        "AA" => AA,
+        "Aa" => Aa,
+        "aa" => aa,
+        # end Mendelian
+        )
 
 const MALE_FEMALE_RELEASE_FRACTION = 0.5
+
+
+
+
+
+
+
+
+const genetics_key_map = Constants(Dict(
+    :key1 => "value1",
+    :key2 => "value2"
+))
+
+end

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -40,11 +40,3 @@ const MALE_FEMALE_RELEASE_FRACTION = 0.5
 
 
 
-
-
-const genetics_key_map = Constants(Dict(
-    :key1 => "value1",
-    :key2 => "value2"
-))
-
-end

--- a/testing_genedrive.jl
+++ b/testing_genedrive.jl
@@ -1,0 +1,5 @@
+using Pkg
+Pkg.activate(".")
+include("src/GeneDrive.jl")
+using .GeneDrive
+


### PR DESCRIPTION
From #11 

When I forked the repo, re-arranged the include as 

```julia


include("genetics.jl")


include("temperature.jl")
include("temperature_responses.jl")

include("life_stages.jl") 
include("organisms.jl")
include("definitions.jl")  

include("spatial_structure.jl")
...
```

I was able to call `assign_migration!(network, migration_data, species);` without error. 

Though if I ran the package locally as a module by calling:

```julia
using Pkg
Pkg.activate(".")
include("src/GeneDrive.jl")
using .GeneDrive
```

It works as is in your package. 

